### PR TITLE
fix Makefile.am to include bluetooth headers

### DIFF
--- a/src/asound/Makefile.am
+++ b/src/asound/Makefile.am
@@ -20,8 +20,10 @@ asound_module_ctldir = @ALSA_PLUGIN_DIR@
 asound_module_pcmdir = @ALSA_PLUGIN_DIR@
 asound_module_confdir = @ALSA_CONF_DIR@
 
+# bluetooth.h is included, for example by bluealsa-pcm.c, so BLUEZ_CFLAGS needs to be included below
 AM_CFLAGS = \
 	-I$(top_srcdir)/src \
+	@BLUEZ_CFLAGS@ \
 	@ALSA_CFLAGS@ \
 	@DBUS1_CFLAGS@
 


### PR DESCRIPTION
The current Makefile.am was not including bluetooth headers path in AM_CFLAGS